### PR TITLE
removed cookbooks from Berksfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,10 +4,4 @@ metadata
 
 cookbook 'rs-base', github: 'rightscale-cookbooks/rs-base'
 cookbook 'rs-storage', github: 'rightscale-cookbooks/rs-storage'
-cookbook 'filesystem', github: 'rightscale-cookbooks-contrib/filesystem_cookbook', branch: 'update_lvm_cookbook_dependency_3'
-cookbook 'marker', github: 'rightscale-cookbooks/marker'
-cookbook 'rightscale_backup', github: 'rightscale-cookbooks/rightscale_backup'
-cookbook 'rightscale_volume', github: 'rightscale-cookbooks/rightscale_volume'
-cookbook 'rightscale_tag', github: 'rightscale-cookbooks/rightscale_tag'
-cookbook 'machine_tag', github: 'rightscale-cookbooks/machine_tag'
 cookbook 'mongodb', github: 'sous-chefs/mongodb', tag: 'v0.17.0'


### PR DESCRIPTION
Resolved issues:
TusharSghtScale:rsc_mongodb tushar$ berks install
Resolving cookbook dependencies...
Fetching 'mongodb' from https://github.com/sous-chefs/mongodb.git (at v0.17.0)
Fetching 'rs-base' from https://github.com/rightscale-cookbooks/rs-base.git (at master)
Fetching 'rs-storage' from https://github.com/rightscale-cookbooks/rs-storage.git (at master)
Fetching 'rsc_mongodb' from source at .
Fetching cookbook index from https://supermarket.chef.io...
Using apt (6.0.1)
Using build-essential (8.0.0)
Using chef-sugar (3.4.0)
Installing chef_handler (2.1.0)
Using collectd (2.2.4)
Using collectd_plugins (2.1.3)
Using compat_resource (12.16.3)
Using ephemeral_lvm (3.0.0)
Installing filesystem (0.11.1)
Using lvm (4.0.5)
Installing machine_tag (2.0.4)
Installing marker (2.0.0)
Using mingw (2.0.0)
Using mongodb (0.17.0) from https://github.com/sous-chefs/mongodb.git (at v0.17.0)
Using now (1.0.0)
Using ntp (3.3.1)
Using ohai (5.0.0)
Using poise (2.7.2)
Using poise-service (1.4.2)
Installing python (1.4.6)
Installing rightscale_backup (2.0.0)
Installing rightscale_tag (2.0.1)
Installing rightscale_volume (2.0.0)
Using rs-base (2.1.1) from https://github.com/rightscale-cookbooks/rs-base.git (at master)
Using rs-storage (2.0.1) from https://github.com/rightscale-cookbooks/rs-storage.git (at master)
Using rsc_mongodb (2.0.0) from source at .
Using rsyslog (6.0.1)
Installing selinux_policy (2.0.0)
Using seven_zip (2.0.2)
Using swap (2.0.0)
Installing sysctl (0.8.1)
Installing windows (3.0.2)
Installing xfs (2.0.1)
Using yum (5.0.0)
Using yum-epel (2.1.1)
