### PR TITLE
Fix rsc backups

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'premium@rightscale.com'
 license          'Apache 2.0'
 description      'Installs/Configures Mongo DB'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.2'
+version          '2.0.3'
 chef_version '>= 12.9'
 issues_url 'https://github.com/RightScale-Services-Cookbooks/rsc_mondodb/issues'
 source_url 'https://github.com/RightScale-Services-Cookbooks/rsc_mondodb'

--- a/templates/default/mongodb_backup.erb
+++ b/templates/default/mongodb_backup.erb
@@ -4,10 +4,10 @@ export chef_dir=$HOME/.chef
 mkdir -p $chef_dir
 
 #get instance data to pass to chef server
-instance_data=$(rsc --rl10 cm15 index_instance_session  /api/sessions/instance)
-instance_uuid=$(echo "$instance_data" | rsc --x1 '.monitoring_id' json)
-instance_id=$(echo "$instance_data" | rsc --x1 '.resource_uid' json)
-monitoring_server=$(echo "$instance_data" | rsc --x1 '.monitoring_server' json)
+instance_data=$(/usr/local/bin/rsc --rl10 cm15 index_instance_session  /api/sessions/instance)
+instance_uuid=$(echo "$instance_data" | /usr/local/bin/rsc --x1 '.monitoring_id' json)
+instance_id=$(echo "$instance_data" | /usr/local/bin/rsc --x1 '.resource_uid' json)
+monitoring_server=$(echo "$instance_data" | /usr/local/bin/rsc --x1 '.monitoring_server' json)
 
 if [ -e $chef_dir/backups.json ]; then
   rm -f $chef_dir/backups.json


### PR DESCRIPTION
Added /usr/local/bin/ in front of rsc so that it would be picked up.
The error we were seeing.
/usr/bin/mongodb_backup.sh: line 7: rsc: command not found

Crontab was installed correctly but the command would error out when we ran it manually. 
Now the backup runs and completes via crontab
rs_backup:lineage=mongodb_backups_newd*******d*****
