### PR TITLE
added \ after RANDOM because cron terminates it when it encounters modulo

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'premium@rightscale.com'
 license          'Apache 2.0'
 description      'Installs/Configures Mongo DB'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.3'
+version          '2.0.4'
 chef_version '>= 12.9'
 issues_url 'https://github.com/RightScale-Services-Cookbooks/rsc_mondodb/issues'
 source_url 'https://github.com/RightScale-Services-Cookbooks/rsc_mondodb'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -76,7 +76,7 @@ if node['rsc_mongodb']['use_storage'] == 'true' && node['rsc_mongodb']['restore_
   cron 'mongodb-backup' do
     minute  '0'
     hour    '*/1'
-    command 'sleep $[RANDOM%300];/usr/bin/mongodb_backup.sh'
+    command 'sleep $[RANDOM\%300];/usr/bin/mongodb_backup.sh'
     user    'root'
   end
   # mongo --quiet --eval "d=db.isMaster(); print( d['ismaster'] );"


### PR DESCRIPTION
https://stackoverflow.com/questions/9049460/cron-jobs-and-random-times-within-given-hours
Needed to render modulus as '\%' above because cron terminates the line when it encounters an unescaped '%'.

# Chef Name: mongodb-backup
49 */1 * * * sleep $[RANDOM\%300];/usr/bin/mongodb_backup.sh

mongo-03:/var/log# tail -f syslog 
Jun 28 14:49:01 dev-digitaldeals-mongo-03 CRON[30031]: (root) CMD (sleep $[RANDOM%300];/usr/bin/mongodb_backup.sh)

rs_backup:backup_id=f037fac8-5c10-11e7-b41c-0242ac110002
rs_backup:committed=true
rs_backup:count=1
rs_backup:device=/dev/xvdf
rs_backup:from_master=false
rs_backup:lineage=mongodb_backups_****
rs_backup:position=1
rs_backup:timestamp=1498661348	2017-06-28 10:49:08 EDT