### PR TITLE
Adding ability to select both mongo 3.0 and 3.4 as an input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ rsc_mongodb Cookbook CHANGELOG
 
 This file is used to list changes made in each version of the rsc_mongodb cookbook.
 
+v2.0.5
+------
+  - adding mongo version 3.4 as an input
+  - matching version with mongodb servertemplate
+
 v2.0.2
 -----
   - intiate replica set if block fixed

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,3 +6,4 @@ default['build-essential']['compile_time'] = true
 default['mongodb']['config']['keyFile'] = '/etc/mongodb_keyfile'
 default['rsc_mongodb']['user'] = 'root'
 default['rsc_mongodb']['password'] = 'rootpass'
+default['rsc_mongodb']['mongo_version'] = '3.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -127,7 +127,6 @@ attribute 'rsc_mongodb/mongo_version',
   required: 'required',
   category: 'MongoDB',
   type: 'string',
-  default: '3.0'
-  choice: %w(3.0 3.4)
-
+  default: '3.0',
+  choice: %w(3.0 3.4),
   recipes: ['rsc_mongodb::default']

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'premium@rightscale.com'
 license          'Apache 2.0'
 description      'Installs/Configures Mongo DB'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.4'
+version          '2.0.5'
 chef_version '>= 12.9'
 issues_url 'https://github.com/RightScale-Services-Cookbooks/rsc_mondodb/issues'
 source_url 'https://github.com/RightScale-Services-Cookbooks/rsc_mondodb'
@@ -120,3 +120,14 @@ attribute 'rsc_mongodb/password',
   category: 'MongoDB',
   type: 'string',
   recipes: ['rsc_mongodb::volume_default', 'rsc_mongodb::add_to_replicaset']
+
+attribute 'rsc_mongodb/mongo_version',
+  display_name: 'MongoDB Version',
+  description: 'mongo version 3.0 or 3.4',
+  required: 'required',
+  category: 'MongoDB',
+  type: 'string',
+  default: '3.0'
+  choice: %w(3.0 3.4)
+
+  recipes: ['rsc_mongodb::default']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,9 +39,9 @@ include_recipe 'machine_tag::default'
 
 case node['platform']
 when 'ubuntu'
-  file '/etc/apt/sources.list.d/mongodb-org-node['rsc_mongodb']['mongo_version'].list' do
+  file "/etc/apt/sources.list.d/mongodb-org-#{node['rsc_mongodb']['mongo_version']}.list" do
     action :create_if_missing
-    content 'deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/node['rsc_mongodb']['mongo_version'] multiverse'
+    content "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/#{node['rsc_mongodb']['mongo_version']} multiverse"
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,9 +39,9 @@ include_recipe 'machine_tag::default'
 
 case node['platform']
 when 'ubuntu'
-  file '/etc/apt/sources.list.d/mongodb-org-3.0.list' do
+  file '/etc/apt/sources.list.d/mongodb-org-node['rsc_mongodb']['mongo_version'].list' do
     action :create_if_missing
-    content 'deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.0 multiverse'
+    content 'deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/node['rsc_mongodb']['mongo_version'] multiverse'
   end
 end
 


### PR DESCRIPTION
@rshade @gonzalez 
mongo replica set restore:
![tusharshah_upgrade-dev-productapi-mongo-01-34____ _-ssh_-l_tusharshah_ec2-34-198-51-71_compute-1_amazonaws_com_ _223x67](https://user-images.githubusercontent.com/5281839/29686591-912201d8-88e7-11e7-8e8f-e7329bf4e452.png)

mongo input on st:
![upgrade-dev-productapi-mongo-01-34_-_server_inputs](https://user-images.githubusercontent.com/5281839/29686725-1353733a-88e8-11e7-87b2-8dea3e24e7c6.png)

mongo backup:
![volume_snapshots](https://user-images.githubusercontent.com/5281839/29686828-65141558-88e8-11e7-94f7-3116c0708865.png)